### PR TITLE
モデルの作成、その他

### DIFF
--- a/laravel/.editorconfig
+++ b/laravel/.editorconfig
@@ -11,5 +11,5 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.{yml,yaml}]
+[*.{yml,yaml,json}]
 indent_size = 2

--- a/laravel/.editorconfig
+++ b/laravel/.editorconfig
@@ -11,5 +11,5 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.{yml,yaml,json}]
+[*.{yml,yaml}]
 indent_size = 2

--- a/laravel/app/Models/Profile.php
+++ b/laravel/app/Models/Profile.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Profile extends Model
+{
+    use HasFactory;
+
+    protected $table = 'profile';
+    protected $primaryKey = 'id';
+
+    function rpg()
+    {
+        return $this->hasOne(RPG::class, 'uid', 'uid');
+    }
+}

--- a/laravel/app/Models/Profile.php
+++ b/laravel/app/Models/Profile.php
@@ -12,6 +12,10 @@ class Profile extends Model
     protected $table = 'profile';
     protected $primaryKey = 'id';
 
+    protected $attributes = [
+        'is_registered' => false,
+    ];
+
     function rpg()
     {
         return $this->hasOne(RPG::class, 'uid', 'uid');

--- a/laravel/app/Models/RPG.php
+++ b/laravel/app/Models/RPG.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class RPG extends Model
+{
+    use HasFactory;
+
+    protected $table = 'rpg';
+    protected $primaryKey = 'id';
+
+    function profile()
+    {
+        return $this->belongsTo(Profile::class, 'uid', 'uid');
+    }
+}

--- a/laravel/app/Models/RPG.php
+++ b/laravel/app/Models/RPG.php
@@ -12,6 +12,15 @@ class RPG extends Model
     protected $table = 'rpg';
     protected $primaryKey = 'id';
 
+    protected $attributes = [
+        'point' => 20000,
+        'individual' => 1,
+        'item_limit_count' => 7,
+        'bp_level' => 1,
+        'bp_type' => 'normal',
+        'rate' => 3000,
+    ];
+
     function profile()
     {
         return $this->belongsTo(Profile::class, 'uid', 'uid');

--- a/laravel/database/migrations/2021_03_14_223454_create_profile_table.php
+++ b/laravel/database/migrations/2021_03_14_223454_create_profile_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateProfileTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('profile', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->string('uid', 33)->unique();
+            $table->text('display_name')->nullable();
+            $table->text('picture_url')->nullable();
+            $table->text('status_message')->nullable();
+            $table->text('lang')->nullable();
+            $table->boolean('is_registered')->default(false);
+            $table->integer('donation')->default(0);
+            $table->text('last_word')->nullable();
+            $table->text('regulation_words')->nullable();
+            $table->timestamp('regulation_timestamp')->nullable();
+            $table->text('invite_code')->nullable();
+            $table->text('used_invite_code')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('profile');
+    }
+}

--- a/laravel/database/migrations/2021_03_14_224236_create_rpg_table.php
+++ b/laravel/database/migrations/2021_03_14_224236_create_rpg_table.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateRpgTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('rpg', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->string('uid', 33)->unique();
+            $table->text('player_name')->nullable();
+            $table->text('player_id')->nullable();
+            $table->integer('level')->default(1);
+            $table->integer('exp')->default(0);
+            $table->integer('point')->default(20000);
+            $table->integer('individual')->default(1);
+            $table->text('type')->nullable();
+            $table->text('item')->nullable();
+            $table->text('party')->nullable();
+            $table->text('party_request')->nullable();
+            $table->integer('point_update')->default(0);
+            $table->integer('exp_update')->default(0);
+            $table->integer('item_limit_count')->default(7);
+            $table->integer('coin')->default(0);
+            $table->timestamp('last_login')->nullable();
+            $table->integer('total_login_count')->default(0);
+            $table->integer('continuous_login_count')->default(0);
+            $table->text('same_skill_1')->nullable();
+            $table->text('same_skill_2')->nullable();
+            $table->text('same_skill_3')->nullable();
+            $table->text('same_skill_4')->nullable();
+            $table->text('free_skill_1')->nullable();
+            $table->text('free_skill_2')->nullable();
+            $table->text('free_skill_3')->nullable();
+            $table->text('free_skill_4')->nullable();
+            $table->timestamp('limit_exp_boost')->nullable();
+            $table->timestamp('limit_point_boost')->nullable();
+            $table->integer('bp_level')->default(1);
+            $table->integer('bp_point')->default(0);
+            $table->string('bp_type')->default('normal');
+            $table->integer('rate')->default(3000);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('rpg');
+    }
+}

--- a/laravel/okojo/Controllers/ProfileController.php
+++ b/laravel/okojo/Controllers/ProfileController.php
@@ -1,5 +1,49 @@
 <?php
 
+/**
+ *     okojo-gm-oss - linebot okojoGM Open Source
+ *     Copyright (C) 2021  nanato12 <admin@nanato12.info>
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Also add information on how to contact you by electronic and paper mail.
+ *
+ *   If the program does terminal interaction, make it output a short
+ * notice like this when it starts in an interactive mode:
+ *
+ *     okojo-gm-oss  Copyright (C) 2021  nanato12 <admin@nanato12.info>
+ *     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+ *     This is free software, and you are welcome to redistribute it
+ *     under certain conditions; type `show c' for details.
+ *
+ * The hypothetical commands `show w' and `show c' should show the appropriate
+ * parts of the General Public License.  Of course, your program's commands
+ * might be different; for a GUI interface, you would use an "about box".
+ *
+ *   You should also get your employer (if you work as a programmer) or school,
+ * if any, to sign a "copyright disclaimer" for the program, if necessary.
+ * For more information on this, and how to apply and follow the GNU GPL, see
+ * <https://www.gnu.org/licenses/>.
+ *
+ *   The GNU General Public License does not permit incorporating your program
+ * into proprietary programs.  If your program is a subroutine library, you
+ * may consider it more useful to permit linking proprietary applications with
+ * the library.  If this is what you want to do, use the GNU Lesser General
+ * Public License instead of this License.  But first, please read
+ * <https://www.gnu.org/licenses/why-not-lgpl.html>.
+ */
+
 namespace OkojoBot\Controllers;
 
 use App\Models\Profile;

--- a/laravel/okojo/Controllers/ProfileController.php
+++ b/laravel/okojo/Controllers/ProfileController.php
@@ -5,13 +5,28 @@ namespace OkojoBot\Controllers;
 use App\Models\Profile;
 use App\Models\RPG;
 
+interface IProfileController
+{
+    /**
+     * 新規登録する関数
+     */
+    function register(): void;
+
+    /**
+     * 新規登録済か判定する関数
+     *
+     * @return bool
+     */
+    function isRegistered(): bool;
+}
+
 /**
  * ユーザープロフィールを管理するコントローラ
  *
  * @property string $uid ユーザーID
  * @property Profile $profile Profileモデル
  */
-class ProfileController
+class ProfileController implements IProfileController
 {
     /**
      * @var string $uid ユーザーID
@@ -26,6 +41,10 @@ class ProfileController
     function __construct(string $uid)
     {
         $this->uid = $uid;
+
+        /**
+         * @var null|Profile　$profile Profileモデル
+         */
         $profile = Profile::where('uid', $uid)->first();
         if (is_null($profile)) {
             $profile = new Profile;
@@ -36,5 +55,16 @@ class ProfileController
             );
         }
         $this->profile = $profile;
+    }
+
+    function register(): void
+    {
+        $this->profile->is_registered = true;
+        $this->profile->save();
+    }
+
+    function isRegistered(): bool
+    {
+        return $this->profile->is_registered;
     }
 }

--- a/laravel/okojo/Controllers/ProfileController.php
+++ b/laravel/okojo/Controllers/ProfileController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OkojoBot\Controllers;
+
+use App\Models\Profile;
+use App\Models\RPG;
+
+/**
+ * ユーザープロフィールを管理するコントローラ
+ *
+ * @property string $uid ユーザーID
+ * @property Profile $profile Profileモデル
+ */
+class ProfileController
+{
+    /** @var string $uid ユーザーID */
+    public $uid;
+    /** @var Profile $profile Profileモデル */
+    public $profile;
+
+    function __construct(string $uid)
+    {
+        $this->uid = $uid;
+        $profile = Profile::where('uid', $uid)->first();
+        if (is_null($profile)) {
+            $profile = new Profile;
+            $profile->uid = $this->uid;
+            $profile->save();
+            $profile->rpg()->save(
+                new RPG()
+            );
+        }
+        $this->profile = $profile;
+    }
+}

--- a/laravel/okojo/Controllers/ProfileController.php
+++ b/laravel/okojo/Controllers/ProfileController.php
@@ -13,9 +13,14 @@ use App\Models\RPG;
  */
 class ProfileController
 {
-    /** @var string $uid ユーザーID */
+    /**
+     * @var string $uid ユーザーID
+     */
     public $uid;
-    /** @var Profile $profile Profileモデル */
+
+    /**
+     * @var Profile $profile Profileモデル
+     */
     public $profile;
 
     function __construct(string $uid)

--- a/laravel/tests/Unit/OkojoBot/Controllers/ProfileControllerTest.php
+++ b/laravel/tests/Unit/OkojoBot/Controllers/ProfileControllerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit\OkojoBot\Controllers;
+
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use OkojoBot\Controllers\ProfileController;
+use Tests\TestCase;
+
+class ProfileControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * インスタンステスト
+     *
+     * @return void
+     */
+    public function testInit()
+    {
+        $profileController = new ProfileController("test_is_registered");
+        $this->assertEquals(
+            "test_is_registered",
+            $profileController->uid,
+            "引数のuidとprofileControllerのuidが一致すること。",
+        );
+    }
+
+    public function testIsRegistered()
+    {
+        $profileController = new ProfileController("test_is_registered");
+        $this->assertEquals(
+            false,
+            $profileController->isRegistered(),
+            "初期であれば、isRegistered は false になること。"
+        );
+    }
+}

--- a/laravel/tests/Unit/OkojoBot/Models/ProfileTest.php
+++ b/laravel/tests/Unit/OkojoBot/Models/ProfileTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit\OkojoBot\Models;
+
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class ProfileTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * Profileモデルのインスタンステスト
+     *
+     * @return void
+     */
+    public function testInit()
+    {
+        $profile = new Profile();
+        $profile->uid = "test_init_profile_uid";
+        $profile->save();
+
+        $this->assertEquals(
+            "test_init_profile_uid",
+            $profile->uid,
+            "登録したUIDであること。"
+        );
+        $this->assertEquals(
+            null,
+            $profile->display_name,
+            "display_name の初期値は NULL であること。"
+        );
+        $this->assertEquals(
+            null,
+            $profile->picture_url,
+            "picture_url の初期値は NULL であること。"
+        );
+        $this->assertEquals(
+            null,
+            $profile->status_message,
+            "status_message の初期値は NULL であること。"
+        );
+        $this->assertEquals(
+            null,
+            $profile->lang,
+            "lang の初期値は NULL であること。"
+        );
+        $this->assertEquals(
+            null,
+            $profile->last_word,
+            "last_word の初期値は NULL であること。"
+        );
+        $this->assertEquals(
+            null,
+            $profile->regulation_words,
+            "regulation_words の初期値は NULL であること。"
+        );
+        $this->assertEquals(
+            null,
+            $profile->invite_code,
+            "invite_code の初期値は NULL であること。"
+        );
+        $this->assertEquals(
+            null,
+            $profile->used_invite_code,
+            "used_invite_code の初期値は NULL であること。"
+        );
+        $this->assertEquals(
+            null,
+            $profile->regulation_timestamp,
+            "regulation_timestamp の初期値は NULL であること。"
+        );
+        $this->assertEquals(
+            false,
+            $profile->is_registered,
+            "is_registered の初期値は false であること。"
+        );
+        $this->assertEquals(
+            0,
+            $profile->donation,
+            "donation の初期値は 0 であること。"
+        );
+    }
+}

--- a/laravel/tests/Unit/OkojoBot/Models/RPGTest.php
+++ b/laravel/tests/Unit/OkojoBot/Models/RPGTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Tests\Unit\OkojoBot\Models;
+
+use App\Models\RPG;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class RPGTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * PRGモデルのインスタンステスト
+     *
+     * @return void
+     */
+    public function testInit()
+    {
+        $rpg = new RPG;
+        $rpg->uid = "test_init_rpg_uid";
+        $rpg->save();
+
+        $this->assertEquals(
+            "test_init_rpg_uid",
+            $rpg->uid,
+            "登録したUIDであること。"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->player_name,
+            "player_name の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->player_id,
+            "player_id の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->level,
+            "level の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->exp,
+            "exp の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            20000,
+            $rpg->point,
+            "point の初期値は 20000 であること"
+        );
+        $this->assertEquals(
+            1,
+            $rpg->individual,
+            "individual の初期値は 0 であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->type,
+            "type の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->item,
+            "item の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->party,
+            "party の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->party_request,
+            "party_request の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            0,
+            $rpg->point_update,
+            "point_update の初期値は 0 であること"
+        );
+        $this->assertEquals(
+            0,
+            $rpg->exp_update,
+            "exp_update の初期値は 0 であること"
+        );
+        $this->assertEquals(
+            7,
+            $rpg->item_limit_count,
+            "item_limit_count の初期値は 7 であること"
+        );
+        $this->assertEquals(
+            0,
+            $rpg->coin,
+            "coin の初期値は 0 であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->last_login,
+            "last_login の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            0,
+            $rpg->total_login_count,
+            "total_login_count の初期値は 0 であること"
+        );
+        $this->assertEquals(
+            0,
+            $rpg->continuous_login_count,
+            "continuous_login_count の初期値は 0 であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->same_skill_1,
+            "same_skill_1 の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->same_skill_2,
+            "same_skill_2 の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->same_skill_3,
+            "same_skill_3 の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->same_skill_4,
+            "same_skill_4 の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->free_skill_1,
+            "free_skill_1 の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->free_skill_2,
+            "free_skill_2 の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->free_skill_3,
+            "free_skill_3 の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->free_skill_4,
+            "free_skill_4 の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->limit_exp_boost,
+            "limit_exp_boost の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            null,
+            $rpg->limit_point_boost,
+            "limit_point_boost の初期値は NULL であること"
+        );
+        $this->assertEquals(
+            1,
+            $rpg->bp_level,
+            "bp_level の初期値は 1 であること"
+        );
+        $this->assertEquals(
+            0,
+            $rpg->bp_point,
+            "bp_point の初期値は 0 であること"
+        );
+        $this->assertEquals(
+            "normal",
+            $rpg->bp_type,
+            "bp_type の初期値は 'normal' であること"
+        );
+        $this->assertEquals(
+            3000,
+            $rpg->rate,
+            "rate の初期値は 3000 であること"
+        );
+    }
+}


### PR DESCRIPTION
# 概要
Botで扱うユーザープロフィールモデルの作成

# 技術的変更点
- マイグレーションの追加
  - `laravel/database/migrations/2021_03_14_223454_create_profile_table.php`
  - `laravel/database/migrations/2021_03_14_224236_create_rpg_table.php`
- `laravel/app/Models/Profile.php`
  - Profileモデルの作成
- `laravel/app/Models/RPG.php`
  - RPGモデルの作成
- `laravel/okojo/Controllers/ProfileController.php`
  - プロフィールを扱うコントローラの作成
- テストの追加
  - `laravel/tests/Unit/OkojoBot/Models/ProfileTest.php`
  - `laravel/tests/Unit/OkojoBot/Models/RPGTest.php` 
  - `laravel/tests/Unit/OkojoBot/Controllers/ProfileControllerTest.php`

# 確認事項
- [ ] 

# その他
- 特になし
